### PR TITLE
Updating redis-stack to 6.2.6-v1

### DIFF
--- a/charts/redis-stack-server/Chart.yaml
+++ b/charts/redis-stack-server/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.2.4"
+appVersion: "6.2.6"

--- a/charts/redis-stack-server/values.yaml
+++ b/charts/redis-stack-server/values.yaml
@@ -1,7 +1,7 @@
 name: redis-stack-server
 redis_stack_server:
   image: "redis/redis-stack-server"
-  tag: "6.2.4-v2"
+  tag: "6.2.6-v1"
   port: 6379
   replicas: 1
   storage_class: standard

--- a/charts/redis-stack/Chart.yaml
+++ b/charts/redis-stack/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.2.4"
+appVersion: "6.2.6"

--- a/charts/redis-stack/values.yaml
+++ b/charts/redis-stack/values.yaml
@@ -1,7 +1,7 @@
 name: redis-stack
 redis_stack:
   image: "redis/redis-stack"
-  tag: "6.2.4-v2"
+  tag: "6.2.6-v1"
   redis_insight: "redis-insight"
   redis_insight_port: 8001
   redis_server_port: 6379


### PR DESCRIPTION
This PR will need to be re-run once 6.2.6-v1 is released. This is only a prep PR. It will fail until packages are available.