### PR TITLE
Fix: mount db volume to /data directory

### DIFF
--- a/charts/redis-stack-server/templates/redis-stack-server.yaml
+++ b/charts/redis-stack-server/templates/redis-stack-server.yaml
@@ -35,6 +35,9 @@ spec:
         ports:
         - containerPort: {{ .Values.redis_stack_server.port }}
           name: db
+        volumeMounts:
+        - name: db
+          mountPath: /data
   volumeClaimTemplates:
   - metadata:
       name: db


### PR DESCRIPTION
there is a volume claim but not mounted /data directory.
this patch will mount pvc to /data directory.
