### PR TITLE
[redis-stack] Updated resources to follow the release namespace

### DIFF
--- a/charts/redis-stack/templates/deployment.yaml
+++ b/charts/redis-stack/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ .Values.name }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ .Values.name }}"
 spec:

--- a/charts/redis-stack/templates/service.yaml
+++ b/charts/redis-stack/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ .Values.name }}"
+  namespace: {{ .Release.Namespace }}
   labels:
     app: "{{ .Values.name }}"
 spec:


### PR DESCRIPTION
This change will allow users to deploy the redis-stack in the namespace of their choice