### PR TITLE
chore: update release action to publish on push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Helm Chart Release
 
 on:
-  release:
-    types: [published]
+  push:
+    branches:
+      - main
 
 jobs:
   release:


### PR DESCRIPTION
**Changes**
Trigger "Helm Chart Release" workflow on push to *main* branch.
Rather than, when a release is published.

**Reason**
When a GitHub release is created a new tag is created and pushed to the release branch.
When the "helm/chart-releaser-action" is run in the "Helm Chart Release" workflow, it fetches the latest commit to the triggering branch, and compares changes against it. 

Since the latest tag, is what triggered the workflow, the is no change resulting in the error:  
```
Looking up latest tag...
Discovering changed charts since 'redis-stack-server-0.3.0'...
Nothing to do. No chart changes detected.
```
Mentioned [here](https://github.com/redis-stack/helm-redis-stack/issues/17)

Further more:
- the "helm/chart-releaser-action" generates a GitHub release.
- a branch named: "_gh-pages_" is **required** to publish charts to the helm repo [https://redis-stack.github.io/helm-redis-stack/index.yaml(https://redis-stack.github.io/helm-redis-stack/index.yaml).

More about this found here: [Issue-17](https://github.com/redis-stack/helm-redis-stack/issues/17#issuecomment-1504838017)