### PR TITLE
Disable the check for chart version increments

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false --check-version-increment=false
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.2.0


### PR DESCRIPTION
Enable to push changes to the repo and activates the CI without increment the version