### PR TITLE
feat: add node affinity to Helm chart for improved pod scheduling

### DIFF
--- a/charts/redis-stack-server/Chart.yaml
+++ b/charts/redis-stack-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.10
+version: 0.4.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redis-stack-server/Chart.yaml
+++ b/charts/redis-stack-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.11
+version: 0.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redis-stack-server/templates/redis-stack-server.yaml
+++ b/charts/redis-stack-server/templates/redis-stack-server.yaml
@@ -20,13 +20,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: "{{ .Values.name }}" 
+      app: "{{ .Values.name }}"
   serviceName: "{{ .Values.name }}"
   replicas: {{ .Values.redis_stack_server.replicas }}
   template:
     metadata:
       labels:
-        app: "{{ .Values.name }}" 
+        app: "{{ .Values.name }}"
     spec:
       terminationGracePeriodSeconds: 10
       containers:
@@ -48,3 +48,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.redis_stack_server.storage }}
+{{- if .Values.redis_stack_server.affinity }}
+      affinity:
+{{ toYaml .Values.redis_stack_server.affinity | indent 8 }}
+{{- end }}

--- a/charts/redis-stack-server/values.yaml
+++ b/charts/redis-stack-server/values.yaml
@@ -6,3 +6,4 @@ redis_stack_server:
   replicas: 1
   storage_class: standard
   storage: 1Gi
+  affinity: {}

--- a/charts/redis-stack/Chart.yaml
+++ b/charts/redis-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.10
+version: 0.4.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redis-stack/Chart.yaml
+++ b/charts/redis-stack/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.11
+version: 0.4.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redis-stack/templates/deployment.yaml
+++ b/charts/redis-stack/templates/deployment.yaml
@@ -36,3 +36,7 @@ spec:
             cpu: "{{ .Values.redis_stack.cpu }}"
           {{- end}}
         {{- end}}
+{{- if .Values.redis_stack.affinity }}
+      affinity:
+{{ toYaml .Values.redis_stack.affinity | indent 8 }}
+{{- end }}

--- a/charts/redis-stack/values.yaml
+++ b/charts/redis-stack/values.yaml
@@ -8,3 +8,4 @@ redis_stack:
   replicas: 1
   memory: 1Gi
   cpu: 100m
+  affinity: {}


### PR DESCRIPTION
Added node affinity rules to the Helm chart to ensure that pods are scheduled onto appropriate nodes based on specific criteria. This helps in optimizing resource utilization, enhancing performance, and maintaining workload balance across the cluster.

References:
- Kubernetes affinity and anti-affinity documentation: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity