### PR TITLE
Make redis-stack-server more production ready

### DIFF
--- a/charts/redis-stack-server/Chart.yaml
+++ b/charts/redis-stack-server/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.14
+version: 0.4.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/redis-stack-server/templates/service.yaml
+++ b/charts/redis-stack-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Values.name }}"
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: "{{ .Values.name }}"
+spec:
+  ports:
+  - port: {{ .Values.redis_stack_server.service.port }}
+    name: {{ .Values.name }}
+  type: {{ .Values.redis_stack_server.service.type }}
+  selector:
+    app: "{{ .Values.name }}"
+

--- a/charts/redis-stack-server/templates/statefulset.yaml
+++ b/charts/redis-stack-server/templates/statefulset.yaml
@@ -35,6 +35,20 @@ spec:
             memory: {{ .Values.redis_stack_server.resources.limits.memory }}
             cpu: {{ .Values.redis_stack_server.resources.limits.cpu }}
           {{- end }}
+        readinessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 5
+          periodSeconds: 20
+        livenessProbe:
+          exec:
+            command:
+            - redis-cli
+            - ping
+          initialDelaySeconds: 30
+          periodSeconds: 20
   {{- if .Values.redis_stack_server.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:

--- a/charts/redis-stack-server/templates/statefulset.yaml
+++ b/charts/redis-stack-server/templates/statefulset.yaml
@@ -1,18 +1,3 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: "{{ .Values.name }}"
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: "{{ .Values.name }}"
-spec:
-  ports:
-  - port: {{ .Values.redis_stack_server.port }}
-    name: db
-  type: NodePort
-  selector:
-    app: "{{ .Values.name }}"
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -34,20 +19,33 @@ spec:
         image: {{ .Values.redis_stack_server.image }}:{{ .Values.redis_stack_server.tag }}
         imagePullPolicy: Always
         ports:
-        - containerPort: {{ .Values.redis_stack_server.port }}
-          name: db
+        - containerPort: 6379
+          name: redis
+        {{- if .Values.redis_stack_server.persistence.enabled }}
         volumeMounts:
-        - name: db
+        - name: redis-data
           mountPath: /data
+        {{- end }}
+        resources:
+          {{- if .Values.redis_stack_server.resources }}
+          requests:
+            memory: {{ .Values.redis_stack_server.resources.requests.memory }}
+            cpu: {{ .Values.redis_stack_server.resources.requests.cpu }}
+          limits:
+            memory: {{ .Values.redis_stack_server.resources.limits.memory }}
+            cpu: {{ .Values.redis_stack_server.resources.limits.cpu }}
+          {{- end }}
+  {{- if .Values.redis_stack_server.persistence.enabled }}
   volumeClaimTemplates:
   - metadata:
       name: db
     spec:
       accessModes: [ "ReadWriteOnce" ]
-      storageClassName: {{ .Values.redis_stack_server.storage_class }}
+      storageClassName: {{ .Values.redis_stack_server.storageClass }}
       resources:
         requests:
-          storage: {{ .Values.redis_stack_server.storage }}
+          storage: {{ .Values.redis_stack_server.size | default "1Gi" }}
+  {{- end }}
 {{- if .Values.redis_stack_server.affinity }}
       affinity:
 {{ toYaml .Values.redis_stack_server.affinity | indent 8 }}

--- a/charts/redis-stack-server/values.yaml
+++ b/charts/redis-stack-server/values.yaml
@@ -1,9 +1,20 @@
 name: redis-stack-server
+
 redis_stack_server:
   image: "redis/redis-stack-server"
   tag: "7.4.0-v1"
-  port: 6379
   replicas: 1
-  storage_class: standard
-  storage: 1Gi
-  affinity: {}
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  persistence:
+    enabled: false
+    size: 1Gi
+    # storageClass: standard
+  service:
+    port: 6379
+    type: ClusterIP


### PR DESCRIPTION
Hi, 
I've cleaned up the redis-stack-server chart and added more option to make it more production ready like health probes, optional persistence and clearer settings for resources in values.yaml

If you want I can make similar changes for the redis-stack chart as well 