### PR TITLE
bugfix/ nodeAffinity placement and indentation

### DIFF
--- a/charts/redis-stack-server/templates/redis-stack-server.yaml
+++ b/charts/redis-stack-server/templates/redis-stack-server.yaml
@@ -28,6 +28,10 @@ spec:
       labels:
         app: "{{ .Values.name }}"
     spec:
+    {{- if .Values.redis_stack_server.affinity }}
+      affinity:
+    {{- toYaml .Values.redis_stack_server.affinity | nindent 8 }}
+    {{- end }}
       terminationGracePeriodSeconds: 10
       containers:
       - name: "{{ .Values.name }}"
@@ -48,7 +52,3 @@ spec:
       resources:
         requests:
           storage: {{ .Values.redis_stack_server.storage }}
-{{- if .Values.redis_stack_server.affinity }}
-      affinity:
-{{ toYaml .Values.redis_stack_server.affinity | indent 8 }}
-{{- end }}


### PR DESCRIPTION
Fixed `nodeAffinity` placement in the redis-stack-server `StatefulSet` template.
It previously was rendering under the `spec` of the `volumeClaimTemplates` while it should be placed under the `spec` of the `pod`.