### PR TITLE
Add resource tuning docs and defaults to redis-stack-server chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,22 @@ kubectl exec -it <POD_NAME> -- redis-cli
 ```
 
 By default redis-stack will have no password, Redis Stack supports the ability to configure multiple named users, each with their own password and access control configuration.  Refer to the [Redis Access Control List documentation](https://redis.io/docs/management/security/acl/) for more information. Alternatively the configuration file can be modified and the *requirepass* directive added. This can also be triggered via the *REDIS_ARGS* environment variable. Examples are available on the [docker image page](https://hub.docker.com/repository/docker/redis/redis-stack-server/)
+
+## Production resource tuning
+
+When deploying the production-ready `redis-stack-server` chart, pinning CPU/memory requests and limits is critical so your scheduler can reserve the right capacity. The chart exposes the `redis_stack_server.resources` block in `charts/redis-stack-server/values.yaml`:
+
+```yaml
+redis_stack_server:
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1Gi
+    limits:
+      cpu: 500m
+      memory: 2Gi
+```
+
+Adjust these values for your node sizes (e.g. `cpu: 250m` requests and `cpu: 1` limit with proportional memory) either by editing the values file or overriding via `--set redis_stack_server.resources.requests.memory=...`. Apply the tuned profile with something like `helm upgrade --install redis-stack redis-stack/redis-stack-server -f values-production.yaml`.
+
+Verify the pod receives the requests/limits you expect using `kubectl describe pod <name>` before pushing to production.

--- a/charts/redis-stack-server/templates/redis-stack-server.yaml
+++ b/charts/redis-stack-server/templates/redis-stack-server.yaml
@@ -36,6 +36,10 @@ spec:
         ports:
         - containerPort: {{ .Values.redis_stack_server.port }}
           name: db
+        {{- with .Values.redis_stack_server.resources }}
+        resources:
+{{ toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: db
           mountPath: /data

--- a/charts/redis-stack-server/values.yaml
+++ b/charts/redis-stack-server/values.yaml
@@ -7,3 +7,10 @@ redis_stack_server:
   storage_class: standard
   storage: 1Gi
   affinity: {}
+  resources:
+    requests:
+      cpu: 100m
+      memory: 1Gi
+    limits:
+      cpu: 500m
+      memory: 2Gi


### PR DESCRIPTION
- Document how to pin CPU/memory requests and limits for the production-ready redis-stack-server chart.
- Inject the redis_stack_server.resources block into the pod spec when those values are set.
- Provide default resource requests/limits so pods start with sane reservations.
- Tested on minikube.